### PR TITLE
Fix base path in vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
-  base: 'lineup-crt',
+  base: '/lineup-crt/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary
- correct Vite `base` option

## Testing
- `npm install`
- `npm run build` *(fails: Unexpected "export" error, but base warning is gone)*

------
https://chatgpt.com/codex/tasks/task_e_6867cc106860832a8babf0d8b88a06cb