### PR TITLE
Add lint script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Currently, two official plugins are available:
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 
+## Linting
+
+Run `npm run lint` to check the project with ESLint.
+
+
 ## Deployment
 
 Run `npm run deploy` to publish the contents of the `dist` folder to the `gh-pages` branch. This command relies on the `gh-pages` package and is useful for manual deployments. The repository also includes a GitHub Actions workflow that deploys automatically when changes are pushed to `master`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "lint": "eslint .",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
   },


### PR DESCRIPTION
## Summary
- add lint script to package.json
- document `npm run lint` usage

## Testing
- `npm ci`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867cc127b34832a9c7192e8aa5d3d9c