### PR TITLE
Add visible soccer field background

### DIFF
--- a/public/field.svg
+++ b/public/field.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800">
+  <rect width="1200" height="800" fill="#5fa75f"/>
+  <rect width="1200" height="800" fill="url(#stripes)" opacity="0.2"/>
+  <defs>
+    <pattern id="stripes" width="40" height="40" patternUnits="userSpaceOnUse">
+      <rect width="20" height="40" fill="#6abf69"/>
+      <rect x="20" width="20" height="40" fill="#5fa75f"/>
+    </pattern>
+  </defs>
+  <rect x="10" y="10" width="1180" height="780" fill="none" stroke="white" stroke-width="10"/>
+  <line x1="600" y1="10" x2="600" y2="790" stroke="white" stroke-width="10"/>
+  <circle cx="600" cy="400" r="90" fill="none" stroke="white" stroke-width="10"/>
+  <line x1="10" y1="400" x2="1190" y2="400" stroke="white" stroke-width="10"/>
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Papa from "papaparse";
 import { calculateOverall } from "./utils/overall";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import SoccerBackground from "./components/SoccerBackground";
 import {
     DndContext,
     closestCenter,
@@ -2772,7 +2773,8 @@ export default function App() {
     }, [view]);
 
     return (
-        <div className="min-h-screen bg-gray-50 text-gray-800">
+        <div className="min-h-screen relative overflow-hidden bg-gray-50/90 text-gray-800">
+            {view === "home" && <SoccerBackground />}
             <header
                 className={
                     "z-50 sticky top-0 left-0 w-full transition-all duration-300 bg-white shadow " +

--- a/src/components/SoccerBackground.jsx
+++ b/src/components/SoccerBackground.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import Papa from 'papaparse';
+
+export default function SoccerBackground() {
+  const [images, setImages] = useState([]);
+
+  useEffect(() => {
+    fetch('https://docs.google.com/spreadsheets/d/12sjC6sz8z_ZNKwwQ_IuZc1bfpJr939NZFbB0B26tOIs/export?format=csv')
+      .then(res => res.text())
+      .then(csv => {
+        Papa.parse(csv, {
+          header: true,
+          skipEmptyLines: true,
+          complete: results => {
+            const urls = results.data
+              .map(r => r.Image || r.URL || r[Object.keys(r)[1]])
+              .filter(u => u && u.startsWith('http') && !u.endsWith('.mp4'));
+            setImages(urls);
+          }
+        });
+      });
+  }, []);
+
+  return (
+    <div className="absolute inset-0 z-0 pointer-events-none overflow-hidden">
+      <img src="/field.svg" alt="" className="w-full h-full object-cover opacity-70" />
+      {images.map((url, idx) => {
+        const top = Math.random() * 90;
+        const left = Math.random() * 90;
+        const size = 60 + Math.random() * 120;
+        return (
+          <img
+            key={idx}
+            src={url}
+            alt=""
+            className="absolute blur-md opacity-60"
+            style={{ top: `${top}%`, left: `${left}%`, width: size, transform: 'translate(-50%, -50%)' }}
+          />
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- adjust home page wrapper to allow background to show through
- refine SoccerBackground component with correct CSV URL and z-index

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc2915d60832abba1ed7ded51883d